### PR TITLE
ENH: Add Dockerfile and shell scripts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:14.04
+#QIIME basic installation env v0.1 
+MAINTAINER Chester Kuo <chester.kuo@gmail.com>
+
+RUN apt-get update && apt-get -y install curl
+RUN apt-get -y --no-install-recommends install cmake mercurial git make subversion
+RUN apt-get -y install gcc g++ gdb
+RUN apt-get -y install python python-dev python-pip vim
+RUN apt-get -y install pkg-config libpng-dev libfreetype6-dev
+RUN apt-get -y install libopenblas-base libopenblas-dev libatlas-base-dev gfortran libblas-dev liblapack-dev mklibs
+
+RUN mkdir -p /tmp
+
+RUN pip install numpy
+RUN pip install -U qiime
+
+RUN print_qiime_config.py -t
+
+# upstream and downstream scripts to support the BaseSpace apps
+ADD upstream.sh /upstream.sh
+ADD downstream.sh /downstream.sh

--- a/docker/downstream.sh
+++ b/docker/downstream.sh
@@ -1,0 +1,2 @@
+git clone git://github.com/biocore/basespace-qiime.git
+python basespace-qiime/scripts/downstream.py

--- a/docker/upstream.sh
+++ b/docker/upstream.sh
@@ -1,0 +1,2 @@
+git clone git://github.com/biocore/basespace-qiime.git
+python basespace-qiime/scripts/upstream.py


### PR DESCRIPTION
This is the Dockerfile that powers the Docker image for QIIME running on
BaseSpace, the shell scripts are used by the callback.js files to start
the processing of the data.

@chesterkuo, the Dockerfile included here is part of your repository found in https://github.com/chesterkuo/docker-gpgpu , are you OK with us redistributing
the file under the BSD-2 license? I couldn't find a license in your repository.
