### PR TITLE
BUG: Fix a problem with the report template

### DIFF
--- a/basespace/downstream/summary-report.html
+++ b/basespace/downstream/summary-report.html
@@ -30,12 +30,15 @@
                         {% comment %}
                         I couldn't find a better way to determine which file is
                         corediv-out/index.html so I just grab the first one and
-                        assume that's the one ... need to fix this.
+                        check that the word 'emperor' is not part of the path
                         {% endcomment %}
 
                         {% if key contains 'index.html' %}
-                            {{ result.files[key].content }}
-                            {% break %}
+                            {% if key contains 'emperor' %}
+                                {% continue %}
+                            {% else %}
+                                {{ result.files[key].content }}
+                            {% endif %}
                         {% endif %}
                     {% endfor %}
                 {% endfor %}


### PR DESCRIPTION
In some instances the report would incorrectly try to display an emperor
plot instead of the main 'index.html' file that summarizes the
core-diversity results.

![screen shot 2015-11-06 at 1 25 30 pm](https://cloud.githubusercontent.com/assets/375307/11009170/f213c26a-8489-11e5-9d0b-02535f440875.png)
